### PR TITLE
Fixes write to use set and expire_ttl vs setex directly

### DIFF
--- a/lib/rack/cache/redis_entitystore.rb
+++ b/lib/rack/cache/redis_entitystore.rb
@@ -39,7 +39,7 @@ module Rack
           if ttl.zero?
             [key, size] if cache.set(key, buf.string)
           else
-            [key, size] if cache.setex(key, ttl, buf.string)
+            [key, size] if cache.set(key, buf.string, :expire_in => ttl)
           end
         end
 


### PR DESCRIPTION
This is based off of someone else's code. I'm making a formal pull request so future redis-rack-cache users don't have their memory eaten up by never ending TTLs.

https://github.com/SamSaffron/redis-rack-cache/blob/master/lib/rack/cache/redis_entitystore.rb