### PR TITLE
Adds optional TTL argument to Metastore#write

### DIFF
--- a/lib/rack/cache/redis_metastore.rb
+++ b/lib/rack/cache/redis_metastore.rb
@@ -29,8 +29,12 @@ module Rack
           cache.get(hexdigest(key)) || []
         end
 
-        def write(key, entries)
-          cache.set(hexdigest(key), entries)
+        def write(key, entries, ttl=0)
+          if ttl.zero?
+            cache.set(hexdigest(key), entries)
+          else
+            cache.setex(hexdigest(key), ttl, entries)
+          end
         end
 
         def purge(key)

--- a/test/rack/cache/metastore/redis_test.rb
+++ b/test/rack/cache/metastore/redis_test.rb
@@ -113,6 +113,13 @@ describe Rack::Cache::MetaStore::Redis do
     store_simple_entry('/bad', { 'SOME_THING' => Proc.new {} })
   end
 
+  it 'takes a ttl parameter for #write' do
+    @store.write('/foo', [[{},{}]], 123)
+    data = @store.read('/foo')
+    data.must_equal([[{},{}]])
+  end
+
+
   # Abstract methods ===========================================================
 
   it 'stores a cache entry' do


### PR DESCRIPTION
This simple backwards-compatible API change is a step towards supporting a properly-expiring cache.

See the discussion in redis-store/redis-rack-cache#3 and redis-store/redis-store#209.

The other half of the fix is rtomayko/rack-cache#92.