### PR TITLE
Always set TTL

### DIFF
--- a/lib/rack/cache/redis_entitystore.rb
+++ b/lib/rack/cache/redis_entitystore.rb
@@ -1,4 +1,5 @@
 require 'rack/cache/entitystore'
+require 'redis-rack-cache/version'
 
 module Rack
   module Cache
@@ -36,11 +37,8 @@ module Rack
           buf = StringIO.new
           key, size = slurp(body){|part| buf.write(part) }
 
-          if ttl.zero?
-            [key, size] if cache.set(key, buf.string)
-          else
-            [key, size] if cache.setex(key, ttl, buf.string)
-          end
+          ttl = ::Redis::Rack::Cache::DEFAULT_TTL if ttl.zero?
+          [key, size] if cache.setex(key, ttl, buf.string)
         end
 
         def purge(key)

--- a/lib/rack/cache/redis_entitystore.rb
+++ b/lib/rack/cache/redis_entitystore.rb
@@ -1,5 +1,5 @@
 require 'rack/cache/entitystore'
-require 'redis-rack-cache/version'
+require 'redis-rack-cache/constants'
 
 module Rack
   module Cache

--- a/lib/rack/cache/redis_metastore.rb
+++ b/lib/rack/cache/redis_metastore.rb
@@ -2,6 +2,7 @@ require 'digest/sha1'
 require 'rack/utils'
 require 'rack/cache/key'
 require 'rack/cache/metastore'
+require 'redis-rack-cache/version'
 
 module Rack
   module Cache
@@ -30,11 +31,8 @@ module Rack
         end
 
         def write(key, entries, ttl=0)
-          if ttl.zero?
-            cache.set(hexdigest(key), entries)
-          else
-            cache.setex(hexdigest(key), ttl, entries)
-          end
+          ttl = ::Redis::Rack::Cache::DEFAULT_TTL if ttl.zero?
+          cache.setex(hexdigest(key), ttl, entries)
         end
 
         def purge(key)

--- a/lib/rack/cache/redis_metastore.rb
+++ b/lib/rack/cache/redis_metastore.rb
@@ -2,7 +2,7 @@ require 'digest/sha1'
 require 'rack/utils'
 require 'rack/cache/key'
 require 'rack/cache/metastore'
-require 'redis-rack-cache/version'
+require 'redis-rack-cache/constants'
 
 module Rack
   module Cache

--- a/lib/redis-rack-cache/constants.rb
+++ b/lib/redis-rack-cache/constants.rb
@@ -1,7 +1,7 @@
 class Redis
   module Rack
     module Cache
-      VERSION = '1.2.2'
+      DEFAULT_TTL = 86_400 * 365 # 1 year
     end
   end
 end

--- a/lib/redis-rack-cache/version.rb
+++ b/lib/redis-rack-cache/version.rb
@@ -2,6 +2,7 @@ class Redis
   module Rack
     module Cache
       VERSION = '1.2.2'
+      DEFAULT_TTL = 86_400 * 365 # 1 year
     end
   end
 end


### PR DESCRIPTION
Not all Redis instances are configured with `maxmemory-policy = volatile-lru` or `allkeys`.
Some have `volatile-ttl` (typical for mixed cache/persistent usage) or even `noeviction`.

For compatibility, a TTL can always be set, defaulting to a long duration (here, 1 year).