### PR TITLE
set rack:cache dependence to ~> 1.6.0

### DIFF
--- a/redis-rack-cache.gemspec
+++ b/redis-rack-cache.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'redis-store', '~> 1.1.0'
-  s.add_dependency 'rack-cache',  '~> 1.2'
+  s.add_dependency 'rack-cache',  '~> 1.6.0'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
@tubbo 
FIxes issue: https://github.com/redis-store/redis-rack-cache/issues/9#issuecomment-187379896

You can see in the changelog for rack-cache that in version 1.6.0 they renamed files from `entitystore` and `metastore` to `entity_store` and `meta_store` respectively: https://github.com/rtomayko/rack-cache/blob/master/CHANGES

This was partially addressed in this commit: https://github.com/redis-store/redis-rack-cache/commit/604368c643311f64881aa09f6b7cf19889e92b75

This pr updates the gemspec to require ~> 1.6.0.
