### PR TITLE
flexible dependencies

### DIFF
--- a/redis-rack-cache.gemspec
+++ b/redis-rack-cache.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'redis-store', '~> 1.3.0'
-  s.add_dependency 'rack-cache',  '~> 1.6.0'
+  s.add_dependency 'redis-store', '< 1.4', '>= 1.2'
+  s.add_dependency 'rack-cache',  '< 1.7', '>= 1.6'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
using `~> x.y.z` is great for apps, but not so much for gems.

I am using
```
gem 'redis-rails', '~> 5.0.1'
gem 'redis-rack-cache', '~> 2.0.1'
```

which both leads to conflicting `redis-store` dependencies.

```
Bundler could not find compatible versions for gem "redis-store":
  In Gemfile:
    redis-rails (~> 5.0.1) was resolved to 5.0.1, which depends on
      redis-actionpack (~> 5.0.0) was resolved to 5.0.1, which depends on
        redis-store (< 1.4.0, >= 1.1.0)

    redis-rack-cache (~> 2.0.1) was resolved to 2.0.1, which depends on
      redis-store (~> 1.3.0)

    redis-rails (~> 5.0.1) was resolved to 5.0.1, which depends on
      redis-store (~> 1.2.0)

    redis-rails (~> 5.0.1) was resolved to 5.0.1, which depends on
      redis-store (~> 1.2.0)
```

this PR should smoothen on this side.
same fix would need to happen on `redis-rails` side
