### PR TITLE
Allow for TLS redis connections

### DIFF
--- a/lib/rack/cache/redis_entitystore.rb
+++ b/lib/rack/cache/redis_entitystore.rb
@@ -31,7 +31,7 @@ module Rack
         end
       end
 
-      REDIS = Redis
+      REDIS = REDISS = Redis
     end
   end
 end

--- a/lib/rack/cache/redis_metastore.rb
+++ b/lib/rack/cache/redis_metastore.rb
@@ -25,7 +25,7 @@ module Rack
         end
       end
 
-      REDIS = Redis
+      REDIS = REDISS = Redis
     end
   end
 end

--- a/redis-rack-cache.gemspec
+++ b/redis-rack-cache.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'redis-store', '>= 1.2', '< 2'
+  s.add_dependency 'redis-store', '>= 1.6', '< 2'
   s.add_dependency 'rack-cache',  '>= 1.6', '< 2'
 
   s.add_development_dependency 'rake',     '~> 10'

--- a/test/rack/cache/entitystore/redis_test.rb
+++ b/test/rack/cache/entitystore/redis_test.rb
@@ -31,6 +31,10 @@ describe Rack::Cache::EntityStore::Redis do
     cache.must_be_kind_of(::Redis)
     cache.id.must_equal("redis://127.0.0.1:6379/0")
 
+    cache = ::Rack::Cache::EntityStore::Redis.resolve(uri("rediss://127.0.0.1")).cache
+    cache.must_be_kind_of(::Redis)
+    cache.instance_variable_get(:@client).scheme.must_equal('rediss')
+
     cache = ::Rack::Cache::EntityStore::Redis.resolve(uri("redis://127.0.0.1:6380")).cache
     cache.id.must_equal("redis://127.0.0.1:6380/0")
 


### PR DESCRIPTION
redis-store/redis-store@79fe6a2db enabled TLS support. Once that commit makes it into a release, `redis-rack-cache` needs to support the `rediss` scheme to allow for TLS compatibility!