### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/redis-rack-cache.gemspec
+++ b/redis-rack-cache.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.license     = 'MIT'
 
-  s.rubyforge_project = 'redis-rack-cache'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.